### PR TITLE
Add Cortex metadata

### DIFF
--- a/.cortex/catalog/argo-rollouts2.yaml
+++ b/.cortex/catalog/argo-rollouts2.yaml
@@ -4,11 +4,11 @@ info:
   title: "argo-rollouts2"
   x-cortex-tag: "argo-rollouts"
   x-cortex-type: service
-  description: >
+  description: |
     Please put a description here.
   x-cortex-git:
     github:
-      repository: "git@github.com:ROKT/test-repo.git"
+      repository: "ROKT/test-repo"
   x-cortex-owners:
     - type: group
       name: "sre"

--- a/.cortex/catalog/argo-rollouts2.yaml
+++ b/.cortex/catalog/argo-rollouts2.yaml
@@ -1,0 +1,41 @@
+openapi: 3.0.0
+info:
+
+  title: "argo-rollouts2"
+  x-cortex-tag: "argo-rollouts"
+  x-cortex-type: service
+  description: >
+    Please put a description here.
+  x-cortex-git:
+    github:
+      repository: "git@github.com:ROKT/test-repo.git"
+  x-cortex-owners:
+    - type: group
+      name: "sre"
+      provider: CORTEX
+
+  # this is effectively a list of tags used to filter services in the UI
+  # currently our only use-case is for filtering services by primary language
+  x-cortex-groups:
+    - "Go"
+
+  # each service should have an OpsGenie schedule
+  x-cortex-oncall:
+    opsgenie:
+      type: SCHEDULE
+      id: "SRE_schedule"
+
+  x-cortex-link:
+    - name: "argo-calendar"
+      type: buildkite
+      url: https://buildkite.com/rokt/argo-calendar
+    - name: "argo"
+      type: buildkite
+      url: https://buildkite.com/rokt/argo
+
+  # additional links may be included here
+  # there's no need to link content the root folder's `./docs` as it gets picked up automatically
+  # consider including resources such as DD dashboards where possible
+  #  - name: RTS Dashboard
+  #    type: dashboard
+  #    url: https://rokt.datadoghq.com/dashboard/ax6-s8t-6dx/release-tracking-services?from_ts=1666560110637&to_ts=1666574510637&live=true


### PR DESCRIPTION
### Background ###

This PR onboards `argo-rollouts2` into [Cortex](https://docs.cortex.io/docs/setup/gitops).

### What Has Changed: ###

We've tried to pick the right values for this service but please review the YAML file for  correctness and update anything that looks wrong.  In particular, double-check the description and the Opsgenie schedule name.

Also consider adding links to DataDog dashboards or anything else that might be useful.

### How Has This Been Tested? ###

This change only adds a YAML metadata file so there should be no need to test the service.

### Notes ###

Get in touch with the [SRE team](https://mail.google.com/chat/u/0/#chat/space/AAAA-Fk7_L4) if you have any questions or anything you'd like to discuss further. :bow: